### PR TITLE
Support functions with hook args

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import { fake, stub } from 'sinon';
 import proxyquire from 'proxyquire';
+import { assert, fake, stub } from 'sinon';
 
 // Stub child_process so we can mock its calls
 const spawnStub = stub();
@@ -11,28 +11,40 @@ const HookShellScriptPlugin = proxyquire('../', {
 });
 
 // Test data
-const testHooks = { beforeRun: ['cat README.md'], afterCompile: ['ls', { command: 'git', args: ['status'] }] };
+const testHooks = {
+  beforeRun: ['cat README.md'],
+  afterCompile: ['ls', { command: 'git', args: ['status'] }],
+  assetEmitted: [name => `touch ${name}`]
+};
 
 // Mocks
-const mockHook = (delay = 0) => ({
-  taps: [],
-  tap: fake(function(name, cb) {
-    this.taps.push({ name, cb });
-  }),
-  runAll: function() {
-    this.taps.map(t => setTimeout(() => t.cb(t.name), delay));
-  }
-});
+function mockHook(ms = 0) {
+  const taps = [];
+  return {
+    taps,
+    tap: fake((name, cb) => taps.push({ name, cb })),
+    async runAll(...args) {
+      return Promise.all(
+        taps.map(async t => {
+          await delay(ms);
+          t.cb(...args);
+        })
+      );
+    }
+  };
+}
 const mockLogger = {
   info: fake(),
   error: fake()
 };
 const createLogger = () => mockLogger;
-const mockCompiler = () => ({
+const mockCompiler = (hooks = {}) => ({
   options: { watch: false },
   hooks: {
     beforeRun: mockHook(),
-    afterCompile: mockHook()
+    afterCompile: mockHook(),
+    assetEmitted: mockHook(),
+    ...hooks
   },
   getInfrastructureLogger: createLogger
 });
@@ -60,126 +72,121 @@ test.beforeEach(() => {
   mockLogger.error.resetHistory();
 });
 
+const delay = ms => new Promise(res => setTimeout(res, ms));
+
 test('it creates a new instance', ({ truthy }) => {
   const plugin = new HookShellScriptPlugin();
   truthy(plugin);
 });
 
-test.cb('it blows up when a hook does not exist', ({ end, is, truthy }) => {
+test('it blows up when a hook does not exist', ({ throws }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
-  try {
-    plugin.apply({ options: {}, hooks: {}, getInfrastructureLogger: createLogger });
-  } catch (e) {
-    truthy(e instanceof Error);
-    is(e.message, '[HookShellScriptPlugin] The hook beforeRun does not exist on the Webpack compiler.');
-    end();
-  }
+  throws(
+    () => plugin.apply({ options: {}, hooks: {}, getInfrastructureLogger: createLogger }),
+    Error,
+    '[HookShellScriptPlugin] The hook beforeRun does not exist on the Webpack compiler.'
+  );
 });
 
-test.cb('it logs errors when in watch mode', ({ end, truthy }) => {
+test('it logs errors when in watch mode', ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
   try {
     plugin.apply({ options: { watch: true }, hooks: {}, getInfrastructureLogger: createLogger });
   } catch (e) {
-    truthy(mockLogger.error.calledWith('The hook beforeRun does not exist on the Webpack compiler.'));
-    end();
+    assert.calledWith(mockLogger.error, 'The hook beforeRun does not exist on the Webpack compiler.');
+    pass();
   }
 });
 
-test('it applies the hooks to the compiler', ({ is }) => {
+test('it applies the hooks to the compiler', ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
   const compiler = mockCompiler();
   plugin.apply(compiler);
-  is(1, compiler.hooks.beforeRun.tap.callCount);
-  is(1, compiler.hooks.afterCompile.tap.callCount);
+  assert.calledOnce(compiler.hooks.beforeRun.tap);
+  assert.calledOnce(compiler.hooks.afterCompile.tap);
+  assert.calledOnce(compiler.hooks.assetEmitted.tap);
+  pass();
 });
 
-test.serial.cb('it runs a script', ({ truthy, end }) => {
+test.serial('it runs a script', async ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
   const compiler = mockCompiler();
   plugin.apply(compiler);
-  compiler.hooks.beforeRun.runAll();
-  compiler.hooks.afterCompile.runAll();
-  setTimeout(() => {
-    truthy(spawnStub.called);
-    truthy(spawnStub.calledWith('cat', ['README.md']));
-    truthy(spawnStub.calledWith('ls', []));
-    truthy(spawnStub.calledWith('git', ['status']));
-    truthy(mockLogger.info.calledWith('Running script: cat README.md'));
-  }, 0);
 
-  setTimeout(() => {
-    completeSpawn('cat', 'exit');
-    truthy(mockLogger.info.calledWith('Completed script: cat README.md'));
-    end();
-  }, 10);
+  await compiler.hooks.beforeRun.runAll();
+  await compiler.hooks.afterCompile.runAll();
+  await compiler.hooks.assetEmitted.runAll('filename');
+
+  assert.callCount(spawnStub, 4);
+  assert.calledWith(spawnStub, 'cat', ['README.md']);
+  assert.calledWith(spawnStub, 'ls', []);
+  assert.calledWith(spawnStub, 'git', ['status']);
+  assert.calledWith(spawnStub, 'touch', ['filename']);
+  assert.calledWith(mockLogger.info, 'Running script: cat README.md');
+
+  await delay(10);
+  completeSpawn('cat', 'exit');
+  assert.calledWith(mockLogger.info, 'Completed script: cat README.md');
+  pass();
 });
 
-test.serial.cb('it kills already running scripts with a SIGTERM', ({ truthy, end }) => {
+test.serial('it kills already running scripts with a SIGTERM', async ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
-  const compiler = mockCompiler();
-  compiler.hooks.beforeRun = mockHook(10);
+  const compiler = mockCompiler({
+    beforeRun: mockHook(10)
+  });
   plugin.apply(compiler);
-  compiler.hooks.beforeRun.runAll();
-  setTimeout(() => {
-    compiler.hooks.beforeRun.runAll();
-  }, 1);
-  setTimeout(() => {
-    completeSpawn('cat', 'exit', 1, 'SIGTERM');
-    truthy(spawnStub.called);
-    truthy(killFake.called);
-    truthy(mockLogger.info.calledWith('Killing script: cat README.md'));
-    end();
-  }, 15);
+
+  await Promise.all([delay(0).then(compiler.hooks.beforeRun.runAll), delay(1).then(compiler.hooks.beforeRun.runAll)]);
+
+  completeSpawn('cat', 'exit', 1, 'SIGTERM');
+  assert.called(spawnStub);
+  assert.called(killFake);
+  assert.calledWith(mockLogger.info, 'Killing script: cat README.md');
+  pass();
 });
 
-test.serial.cb('it kills already running scripts with a SIGINT', ({ truthy, end }) => {
+test.serial('it kills already running scripts with a SIGINT', async ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
-  const compiler = mockCompiler();
-  compiler.hooks.beforeRun = mockHook(10);
+  const compiler = mockCompiler({
+    beforeRun: mockHook(10)
+  });
   plugin.apply(compiler);
-  compiler.hooks.beforeRun.runAll();
-  setTimeout(() => {
-    compiler.hooks.beforeRun.runAll();
-  }, 1);
-  setTimeout(() => {
-    completeSpawn('cat', 'exit', 1, 'SIGINT');
-    truthy(spawnStub.called);
-    truthy(killFake.called);
-    truthy(mockLogger.info.calledWith('Killing script: cat README.md'));
-    end();
-  }, 15);
+
+  await Promise.all([delay(0).then(compiler.hooks.beforeRun.runAll), delay(1).then(compiler.hooks.beforeRun.runAll)]);
+
+  completeSpawn('cat', 'exit', 1, 'SIGINT');
+  assert.called(spawnStub);
+  assert.called(killFake);
+  assert.calledWith(mockLogger.info, 'Killing script: cat README.md');
+  pass();
 });
 
-test.serial.cb('it handles errors when running a script', ({ truthy, end }) => {
+test.serial('it handles errors when running a script', async ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
-  const compiler = mockCompiler();
-  compiler.hooks.beforeRun = mockHook(10);
+  const compiler = mockCompiler({
+    beforeRun: mockHook(10)
+  });
   compiler.options.watch = true;
   plugin.apply(compiler);
-  compiler.hooks.beforeRun.runAll();
-  setTimeout(() => {
-    compiler.hooks.beforeRun.runAll();
-  }, 1);
-  setTimeout(() => {
-    completeSpawn('cat', 'error', 'Uh oh.');
-    truthy(spawnStub.called);
-    truthy(mockLogger.error.calledWith('Error while running `cat README.md`: Uh oh.'));
-    end();
-  }, 15);
+
+  await Promise.all([delay(0).then(compiler.hooks.beforeRun.runAll), delay(1).then(compiler.hooks.beforeRun.runAll)]);
+
+  completeSpawn('cat', 'error', 'Uh oh.');
+  assert.called(spawnStub);
+  assert.calledWith(mockLogger.error, 'Error while running `cat README.md`: Uh oh.');
+  pass();
 });
 
-test.serial.cb('it ignores complete error events that are not term or interupt', ({ end }) => {
+test.serial('it ignores complete error events that are not term or interupt', async ({ pass }) => {
   const plugin = new HookShellScriptPlugin(testHooks);
-  const compiler = mockCompiler();
-  compiler.hooks.beforeRun = mockHook(10);
+  const compiler = mockCompiler({
+    beforeRun: mockHook(10)
+  });
   plugin.apply(compiler);
-  compiler.hooks.beforeRun.runAll();
-  setTimeout(() => {
-    compiler.hooks.beforeRun.runAll();
-  }, 1);
-  setTimeout(() => {
-    completeSpawn('cat', 'exit', 1, 'JUNK');
-    end();
-  }, 15);
+
+  await Promise.all([delay(0).then(compiler.hooks.beforeRun.runAll), delay(1).then(compiler.hooks.beforeRun.runAll)]);
+
+  completeSpawn('cat', 'exit', 1, 'JUNK');
+  pass();
 });


### PR DESCRIPTION
This adds support for functions that take the hook callback parameters as arguments to create the script. This way the run script can depend on for example which file was emitted.

```
module.exports = {
  // ...
  plugins: [
    new HookShellScriptPlugin({
      assetEmitted: [(file, { content, source, outputPath, compilation, targetPath }) => `node postprocess.js ${outputPath}`]
      // ...
    })
  ]
};
```

The function can return either a string or the object `{command, args}`.