### PR TITLE
Improve readme and typescript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,23 @@ module.exports = {
   // ...
   plugins: [
     new HookShellScriptPlugin({
+      // run a single command
       afterEmit: ['npx tsc --emitDeclarationOnly']
-      // ...
+      // run multiple commands in parallel
+      done: [
+        // either as a string
+        'command1 with args',
+        // or as a command with args
+        {command: 'command2', args: ['with', 'args']}
+      ],
+      // run a command based on the hook arguments
+      assetEmitted: [
+        // you can return a string
+        (name, info) => `node ${info.outputPath}`
+        // or an object with command and args
+        (name, info) => ({command: 'node', args: [info.outputPath]})
+      ],
+      // return a command and argrs object
     })
   ]
 };


### PR DESCRIPTION
Just documented the different ways it can be used in the readme.
In the index.js file I've created some jsdoc type definitions so that the types of the function args are inferred based on the hook used.