### PR TITLE
Do not run scripts via shell

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class HookShellScriptPlugin {
     }
     this._log(`Running script: ${key}`);
     if (this._procs[key]) this._killProc(key);
-    this._procs[key] = spawn(command, args, { stdio: 'inherit', shell: true });
+    this._procs[key] = spawn(command, args, { stdio: 'inherit' });
     this._procs[key].on('error', this._onScriptError.bind(this, key));
     this._procs[key].on('exit', this._onScriptComplete.bind(this, key));
   }


### PR DESCRIPTION
This makes killing scripts processes when the build is restarted work.

Before, only the shell process would be killed.

This is not perfect: the script is still responsible for killing its children in the event that it is killed. But at least if it does not have any children, then it will work; and if it does, then in many cases they will be “simple” and only perform one action, and end quickly.

In general, restarting a script will require killing a process tree.